### PR TITLE
Fix Vec implementation and some lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ std = []
 default = ["std"]
 dropck_eyepatch = []
 coerce_unsized = []
+core_intrinsics = []
 dispatch_from_dyn = []
 exact_size_is_empty = []
 fn_traits = []
@@ -27,6 +28,7 @@ receiver_trait = []
 nightly = [
     "dropck_eyepatch",
     "coerce_unsized",
+    "core_intrinsics",
     "dispatch_from_dyn",
     "exact_size_is_empty",
     "fn_traits",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@ macro_rules! vec {
         $crate::vec::from_elem($elem, $n)
     );
     ($($x:expr),*) => ({
-        let mut v = Vec::new();
+        let mut v = $crate::vec::Vec::new();
         $( v.push($x); )*
         v
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,6 @@ pub mod clone;
 pub mod collections;
 pub mod raw_vec;
 
-#[cfg(feature = "std")]
 pub mod vec;
 
 extern crate alloc as liballoc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@
 
 #![cfg_attr(feature = "dropck_eyepatch", feature(dropck_eyepatch))]
 #![cfg_attr(feature = "coerce_unsized", feature(coerce_unsized))]
+#![cfg_attr(feature = "core_intrinsics", feature(core_intrinsics))]
 #![cfg_attr(feature = "dispatch_from_dyn", feature(dispatch_from_dyn))]
 #![cfg_attr(
     any(feature = "coerce_unsized", feature = "dispatch_from_dyn"),

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1535,9 +1535,10 @@ impl<T, B: BuildAllocRef> Vec<T, B> {
     /// assert_eq!(static_ref, &[2, 2, 3]);
     /// ```
     #[inline]
-    pub fn leak<'a>(vec: Vec<T>) -> &'a mut [T]
+    pub fn leak<'a>(vec: Vec<T, B>) -> &'a mut [T]
     where
         T: 'a, // Technically not needed, but kept to be explicit.
+        B::Ref: ReallocRef<Error = crate::Never>,
     {
         Box::leak(vec.into_boxed_slice())
     }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -373,70 +373,6 @@ impl<T> Vec<T> {
             len: 0,
         }
     }
-}
-
-impl<T, B: BuildAllocRef> Vec<T, B> {
-    /// Like `new` but parameterized over the choice of allocator for the returned `Vec`.
-    #[inline]
-    pub fn new_in(a: B::Ref) -> Vec<T, B>
-    where
-        B::Ref: AllocRef<Error = crate::Never>,
-    {
-        Vec {
-            buf: RawVec::new_in(a),
-            len: 0,
-        }
-    }
-
-    /// Like `with_capacity` but parameterized over the choice of allocator for the returned
-    /// `Vec`.
-    #[inline]
-    pub fn with_capacity_in(capacity: usize, a: B::Ref) -> Vec<T, B>
-    where
-        B::Ref: AllocRef<Error = crate::Never>,
-    {
-        Vec {
-            buf: RawVec::with_capacity_in(capacity, a),
-            len: 0,
-        }
-    }
-
-    /// Decomposes a `Vec<T>` into its raw components.
-    ///
-    /// Returns the raw pointer to the underlying data, the length of
-    /// the vector (in elements), and the allocated capacity of the
-    /// data (in elements). These are the same arguments in the same
-    /// order as the arguments to [`from_raw_parts`].
-    ///
-    /// After calling this function, the caller is responsible for the
-    /// memory previously managed by the `Vec`. The only way to do
-    /// this is to convert the raw pointer, length, and capacity back
-    /// into a `Vec` with the [`from_raw_parts`] function, allowing
-    /// the destructor to perform the cleanup.
-    ///
-    /// [`from_raw_parts`]: #method.from_raw_parts
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use alloc_wg::{vec, vec::Vec};
-    /// let v: Vec<i32> = vec![-1, 0, 1];
-    ///
-    /// let (ptr, len, cap) = v.into_raw_parts();
-    ///
-    /// let rebuilt = unsafe {
-    ///     // We can now make changes to the components, such as
-    ///     // transmuting the raw pointer to a compatible type.
-    ///     let ptr = ptr as *mut u32;
-    ///
-    ///     Vec::from_raw_parts(ptr, len, cap)
-    /// };
-    /// assert_eq!(rebuilt, [4294967295, 0, 1]);
-    /// ```
-    pub fn into_raw_parts(self) -> (*mut T, usize, usize) {
-        let mut me = mem::ManuallyDrop::new(self);
-        (me.as_mut_ptr(), me.len(), me.capacity())
-    }
 
     /// Creates a `Vec<T>` directly from the raw components of another vector.
     ///
@@ -501,6 +437,70 @@ impl<T, B: BuildAllocRef> Vec<T, B> {
             buf: RawVec::from_raw_parts(ptr, capacity),
             len: length,
         }
+    }
+}
+
+impl<T, B: BuildAllocRef> Vec<T, B> {
+    /// Like `new` but parameterized over the choice of allocator for the returned `Vec`.
+    #[inline]
+    pub fn new_in(a: B::Ref) -> Vec<T, B>
+    where
+        B::Ref: AllocRef<Error = crate::Never>,
+    {
+        Vec {
+            buf: RawVec::new_in(a),
+            len: 0,
+        }
+    }
+
+    /// Like `with_capacity` but parameterized over the choice of allocator for the returned
+    /// `Vec`.
+    #[inline]
+    pub fn with_capacity_in(capacity: usize, a: B::Ref) -> Vec<T, B>
+    where
+        B::Ref: AllocRef<Error = crate::Never>,
+    {
+        Vec {
+            buf: RawVec::with_capacity_in(capacity, a),
+            len: 0,
+        }
+    }
+
+    /// Decomposes a `Vec<T>` into its raw components.
+    ///
+    /// Returns the raw pointer to the underlying data, the length of
+    /// the vector (in elements), and the allocated capacity of the
+    /// data (in elements). These are the same arguments in the same
+    /// order as the arguments to [`from_raw_parts`].
+    ///
+    /// After calling this function, the caller is responsible for the
+    /// memory previously managed by the `Vec`. The only way to do
+    /// this is to convert the raw pointer, length, and capacity back
+    /// into a `Vec` with the [`from_raw_parts`] function, allowing
+    /// the destructor to perform the cleanup.
+    ///
+    /// [`from_raw_parts`]: #method.from_raw_parts
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use alloc_wg::{vec, vec::Vec};
+    /// let v: Vec<i32> = vec![-1, 0, 1];
+    ///
+    /// let (ptr, len, cap) = v.into_raw_parts();
+    ///
+    /// let rebuilt = unsafe {
+    ///     // We can now make changes to the components, such as
+    ///     // transmuting the raw pointer to a compatible type.
+    ///     let ptr = ptr as *mut u32;
+    ///
+    ///     Vec::from_raw_parts(ptr, len, cap)
+    /// };
+    /// assert_eq!(rebuilt, [4294967295, 0, 1]);
+    /// ```
+    pub fn into_raw_parts(self) -> (*mut T, usize, usize) {
+        let mut me = mem::ManuallyDrop::new(self);
+        (me.as_mut_ptr(), me.len(), me.capacity())
     }
 
     /// Returns the number of elements the vector can hold without

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1454,7 +1454,7 @@ impl<T, B: BuildAllocRef> Vec<T, B> {
         assert!(at <= self.len(), "`at` out of bounds");
 
         let other_len = self.len - at;
-        let mut other = Vec::new_in(self.buf.alloc_ref().0);
+        let mut other = Vec::with_capacity_in(other_len, self.buf.alloc_ref().0);
 
         // Unsafely `set_len` and copy items to `other`.
         unsafe {

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -137,6 +137,7 @@ use crate::{boxed::Box, raw_vec::RawVec};
 /// Use a `Vec<T>` as an efficient stack:
 ///
 /// ```
+/// # use alloc_wg::vec::Vec;
 /// let mut stack = Vec::new();
 ///
 /// stack.push(1);
@@ -325,6 +326,7 @@ impl<T> Vec<T> {
     /// # Examples
     ///
     /// ```unused_variables, unused_mut
+    /// # use alloc_wg::vec::Vec;
     /// let mut vec: Vec<i32> = Vec::new();
     /// ```
     #[inline]
@@ -350,6 +352,7 @@ impl<T> Vec<T> {
     /// # Examples
     ///
     /// ```
+    /// # use alloc_wg::vec::Vec;
     /// let mut vec = Vec::with_capacity(10);
     ///
     /// // The vector contains no items, even though it has capacity for more
@@ -416,7 +419,7 @@ impl<T, B: BuildAllocRef> Vec<T, B> {
     /// # Examples
     ///
     /// ```
-    /// # use alloc_wg::vec;
+    /// # use alloc_wg::{vec, vec::Vec};
     /// let v: Vec<i32> = vec![-1, 0, 1];
     ///
     /// let (ptr, len, cap) = v.into_raw_parts();
@@ -506,6 +509,7 @@ impl<T, B: BuildAllocRef> Vec<T, B> {
     /// # Examples
     ///
     /// ```
+    /// # use alloc_wg::vec::Vec;
     /// let vec: Vec<i32> = Vec::with_capacity(10);
     /// assert_eq!(vec.capacity(), 10);
     /// ```
@@ -581,10 +585,10 @@ impl<T, B: BuildAllocRef> Vec<T, B> {
     /// # Examples
     ///
     /// ```
+    /// # use alloc_wg::vec::Vec;
     /// use alloc_wg::{
     ///     alloc::{AbortAlloc, Global},
     ///     collections::CollectionAllocErr,
-    ///     vec::Vec,
     /// };
     ///
     /// fn process_data(data: &[u32]) -> Result<Vec<u32>, CollectionAllocErr<AbortAlloc<Global>>> {
@@ -626,10 +630,10 @@ impl<T, B: BuildAllocRef> Vec<T, B> {
     /// # Examples
     ///
     /// ```
+    /// # use alloc_wg::vec::Vec;
     /// use alloc_wg::{
     ///     alloc::{AbortAlloc, Global},
     ///     collections::CollectionAllocErr,
-    ///     vec::Vec,
     /// };
     ///
     /// fn process_data(data: &[u32]) -> Result<Vec<u32>, CollectionAllocErr<AbortAlloc<Global>>> {
@@ -662,6 +666,7 @@ impl<T, B: BuildAllocRef> Vec<T, B> {
     /// # Examples
     ///
     /// ```
+    /// # use alloc_wg::vec::Vec;
     /// let mut vec = Vec::with_capacity(10);
     /// vec.extend([1, 2, 3].iter().cloned());
     /// assert_eq!(vec.capacity(), 10);
@@ -688,6 +693,7 @@ impl<T, B: BuildAllocRef> Vec<T, B> {
     /// # Examples
     ///
     /// ```
+    /// # use alloc_wg::vec::Vec;
     /// let mut vec = Vec::with_capacity(10);
     /// vec.extend([1, 2, 3].iter().cloned());
     /// assert_eq!(vec.capacity(), 10);
@@ -721,6 +727,7 @@ impl<T, B: BuildAllocRef> Vec<T, B> {
     /// Any excess capacity is removed:
     ///
     /// ```
+    /// # use alloc_wg::vec::Vec;
     /// let mut vec = Vec::with_capacity(10);
     /// vec.extend([1, 2, 3].iter().cloned());
     ///
@@ -890,6 +897,7 @@ impl<T, B: BuildAllocRef> Vec<T, B> {
     /// # Examples
     ///
     /// ```
+    /// # use alloc_wg::vec::Vec;
     /// // Allocate vector big enough for 4 elements.
     /// let size = 4;
     /// let mut x: Vec<i32> = Vec::with_capacity(size);
@@ -939,6 +947,7 @@ impl<T, B: BuildAllocRef> Vec<T, B> {
     ///
     /// ```no_run
     /// # #![allow(dead_code)]
+    /// # use alloc_wg::vec::Vec;
     /// # // This is just a minimal skeleton for the doc example;
     /// # // don't use this as a starting point for a real library.
     /// # pub struct StreamWrapper { strm: *mut std::ffi::c_void }
@@ -1406,6 +1415,7 @@ impl<T, B: BuildAllocRef> Vec<T, B> {
     /// # Examples
     ///
     /// ```
+    /// # use alloc_wg::vec::Vec;
     /// let mut v = Vec::new();
     /// assert!(v.is_empty());
     ///
@@ -1518,7 +1528,7 @@ impl<T, B: BuildAllocRef> Vec<T, B> {
     /// Simple usage:
     ///
     /// ```
-    /// # use alloc_wg::vec;
+    /// # use alloc_wg::{vec, vec::Vec};
     /// let x = vec![1, 2, 3];
     /// let static_ref: &'static mut [usize] = Vec::leak(x);
     /// static_ref[0] += 1;


### PR DESCRIPTION
There are still lints, which should be resolved like using `Self` instead of `Vec`. When using `Self` 
45a6b85 never would have happend :slightly_smiling_face: 